### PR TITLE
Updating dependencies so example.py will run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,7 @@ ipython_config.py
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
+poetry.lock
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
@@ -158,4 +158,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ readme = "README.md"
 python = "^3.9"
 polars = "0.18.13"
 pandas = "2.0.3"
-pyspark =  "3.4.1"
+pyspark =  "3.3.1"
+pyarrow = "12.0.1"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.20.0"
@@ -18,6 +19,7 @@ delta-spark = "2.1.1"
 pytest = "7.2.0"
 pytest-describe = "^1.0.0"
 ruff = "^0.0.254"
+pyarrow = "12.0.1"
 
 
 [build-system]


### PR DESCRIPTION
I'm getting my local environment set up for development and noticed example.py errors when I run it because pyarrow is missing as a dependency. 

I don't have a ton of experience with poetry, either, so maybe all I need is guidance on setup. When I got the error, I created a fresh venv and then did a `poetry install` at the root of the project which installed all the dependencies listed in pyproject.toml. 

I'm also interested to know if running the current tests by running `pytest` at the root is working for others on their locals or if those are a work in progress.