### PR TITLE
Adding Docker and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:latest
+
+RUN pip install poetry
+
+# Copy only requirements to cache them in docker layer
+WORKDIR /app
+COPY pyproject.toml /app/
+
+# Project initialization:
+RUN poetry config virtualenvs.create false \
+  && poetry install --no-interaction --no-ansi
+
+# Creating folders, and files for a project:
+COPY . /app

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Your custom check start_station_name IS NULL found 978 records that match your f
 Your custom check end_station_name IS NULL found 978 records that match your filter statement
 ```
 
-### Tests and Local Setup
+### Tests / Local Setup / Contributions.
 To develop and work on TinyTimmy locally, a `Docker` image and `docker-compose` is provided.
 
 First, build the image
@@ -141,3 +141,6 @@ First, build the image
 
 To run the local unit tests run ...
 `docker-compose up test`
+
+To simply work inside the Docker container run ...
+`docker run -it tinytimmy /bin/bash`

--- a/README.md
+++ b/README.md
@@ -132,3 +132,12 @@ shape: (10, 2)
 Your custom check start_station_name IS NULL found 978 records that match your filter statement
 Your custom check end_station_name IS NULL found 978 records that match your filter statement
 ```
+
+### Tests and Local Setup
+To develop and work on TinyTimmy locally, a `Docker` image and `docker-compose` is provided.
+
+First, build the image
+`docker build --tag=tinytimmy .`
+
+To run the local unit tests run ...
+`docker-compose up test`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: "3.9"
+services:
+  test:
+    image: "tinytimmy"
+    volumes:
+      - .:/app
+    command: poetry run pytest


### PR DESCRIPTION
Add a `Docker` container and a `docker-compose` file to enable the running of the unit tests locally and make development and installation of depends easier.