### PR TITLE
#21 pre commit pre push

### DIFF
--- a/.git-dev/hooks/prepare-commit-msg
+++ b/.git-dev/hooks/prepare-commit-msg
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# this script is a git hook
+# it runs as the prepare-commit-msg hook
+# it adds the text: ref: <issue-number> to the end of your commit messages
+# it pulls the issue number from the current active branch
+# by default, it looks for Github Issue style issue numbers
+# to change it to look for JIRA, or other issue style formats,
+# change the regex in the `grep -Eo '#[0-9]+'` command below
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+SHA1=$3
+
+BRANCH_NAME=$(git symbolic-ref --short HEAD)
+
+# GitHub-style issues are of the form #123
+ISSUE_NUMBER_PATTERN='#[0-9]+'
+
+ISSUE_NUMBER=$(echo $BRANCH_NAME | grep -Eo $ISSUE_NUMBER_PATTERN)
+
+if [ -n "$ISSUE_NUMBER" ]; then
+  echo -e "\nref: $ISSUE_NUMBER" >> "$COMMIT_MSG_FILE"
+fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,13 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: check-yaml
-    -   id: check-added-large-files
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-yaml
+    - id: check-added-large-files
+    - id: name-tests-test
+      args:
+        - "--pytest-test-first"
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
   rev: v0.0.285

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,21 +10,27 @@ repos:
     - id: name-tests-test
       args:
         - "--pytest-test-first"
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.0.285
+- repo: local
   hooks:
     - id: ruff
-- repo: https://github.com/ambv/black
-  rev: 23.7.0
-  hooks:
+      name: ruff
+      entry: ruff
+      language: system
+      types: [python]
     - id: black
-      # language_version: python3.9
+      name: black
+      entry: black
+      language: system
+      types: [python]
+    - id: hadolint
+      name: Hadolint Dockerfiles
+      entry: hadolint
+      language: system
+      types: ["dockerfile"]
 - repo: local
   hooks:
     - id: pytest-check
       name: pytest-check
       entry: pytest
+      stages: [push]
       language: system
-      pass_filenames: false
-      always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
+default_install_hook_types: [pre-commit, pre-push]
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ pre-commit = "^3.3.3"
 pytest = "^7.4.0"
 pytest-describe = "^2.1.0"
 ruff = "^0.0.286"
+hadolintw = "^1.2.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,14 @@ pandas = "2.0.3"
 pyspark =  "3.3.1"
 pyarrow = "12.0.1"
 
-[tool.poetry.dev-dependencies]
-pre-commit = "^2.20.0"
-pyspark = "3.3.1"
-delta-spark = "2.1.1"
-pytest = "7.2.0"
-pytest-describe = "^1.0.0"
-ruff = "^0.0.254"
-pyarrow = "12.0.1"
-
+[tool.poetry.group.dev.dependencies]
+black = "^23.7.0"
+isort = "^5.12.0"
+mypy = "^1.5.1"
+pre-commit = "^3.3.3"
+pytest = "^7.4.0"
+pytest-describe = "^2.1.0"
+ruff = "^0.0.286"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR does a few things:

- add a git prepare commit message hook that takes a GitHub issue number from the branch name, and append it to the end of the commit message in the form: ref: <issue-number>
- change pre-commit hooks to use local virtual environment to get linting dependencies, as opposed to having pre-commit set up repos for each dependency
- add pre-push as a hook type that gets installed by default when running `pre-commit install`
- fix poetry dev dependencies group name