### PR TITLE
adding a datetime format checker to default checks

### DIFF
--- a/example.py
+++ b/example.py
@@ -29,6 +29,15 @@ def main():
         ["start_station_name IS NULL", "end_station_name IS NULL"]
     )
     print(results)
+    
+    # check datetime column format 
+    tm = TinyTim(source_type="csv", file_path="tinytimmy/202306-divvy-tripdata.csv")
+    print(tm.dataframe.collect())
+    results = tm.default_checks(datetime_dict={
+        "started_at": "%Y-%m-%d %H:%M:%S",
+        "ended_at": "%Y-%m-%d %H:%M:%S",
+    })
+    print(results)
 
 
 if __name__ == "__main__":

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -5,18 +5,92 @@ from tinytimmy.data_quality import DataQuality
 
 def test_null_check():
     dq = DataQuality()
+
+    # No null values test
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    expected_result = pl.DataFrame({})
+    assert dq.null_check(df.lazy()) == expected_result
+
+    # Some null values test
     df = pl.DataFrame({"a": [1, None, 3], "b": [None, 5, 6]})
-    expected_result = pl.DataFrame({"check_type": ['null_check_a', 'null_check_b'], "check_value": [1, 1]})
-    results = dq.null_check(df.lazy())
-    assert expected_result.frame_equal(results)
+
+    expected_result = pl.DataFrame({"a_null_count": [1], "b_null_count": [1]})
+
+    assert dq.null_check(df.lazy()) == expected_result
 
 
 def test_distinct_check():
     dq = DataQuality()
+
+    # All distinct rows test
     df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
     dq.dataframe = df.lazy()
-    already_results = pl.DataFrame({"check_type": [''], "check_value": [1]})
-    output = dq.distinct_check(already_results)
-    output = output.filter(pl.col("check_type") != '')
-    expected_result = pl.DataFrame({"check_type": ['total_count', 'distinct_count'], "check_value": [3, 3]})
-    assert output.frame_equal(expected_result)
+
+    result_df = pl.DataFrame(
+        {
+            "a_null_count": [0],
+            "b_null_count": [0],
+            "total_count": [3],
+            "distinct_count": [3],
+        }
+    )
+
+    assert dq.distinct_check(result_df) == result_df
+
+    # Some duplicates test
+    df = pl.DataFrame({"a": [1, 1, 2], "b": [4, 4, 5]})
+
+    dq.dataframe = df.lazy()
+
+    result_df = pl.DataFrame(
+        {
+            "a_null_count": [0],
+            "b_null_count": [0],
+            "total_count": [3],
+            "distinct_count": [2],
+        }
+    )
+
+    assert dq.distinct_check(result_df) == result_df
+
+
+def test_default_checks():
+    dq = DataQuality()
+
+    # Just a basic test to ensure it combines the results of the other functions
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    dq.dataframe = df.lazy()
+
+    result_df = pl.DataFrame(
+        {
+            "a_null_count": [0],
+            "b_null_count": [0],
+            "total_count": [3],
+            "distinct_count": [3],
+        }
+    )
+
+    assert dq.default_checks() == result_df
+
+
+# Optionally, you can add more test cases for other methods as well.
+
+# Execute tests
+pytest.main(["-v", "-s"])
+
+def test_check_datetime_format(): 
+    dq = DataQuality()
+    df = pl.DataFrame({"started_at": ["2023-08-16 12:00:00", "2023-08-16 12:00:00"], 
+                       "ended_at": ["2023-08-16 12:00:00", "2023-08-16 12:00:00"]})
+    dq.dataframe = df.lazy()
+    result_df = pl.DataFrame(
+        {
+            "started_at_null_count": [0], 
+            "ended_at_null_count": [0],
+        }
+    )
+    datetime_dict = {"started_at": "%Y-%m-%d %H:%M:%S", "ended_at": "%Y-%m-%d %H:%M:%S"}
+    assert dq.check_datetime_format(results=result_df, datetime_dict=datetime_dict) == result_df


### PR DESCRIPTION
Adding a datetime format checker. Method accepts an object with the column name as the key and datetime format as the value. Checks if any values in the column are null after applying the transformation. 